### PR TITLE
Suggestion / question: identical parameter names to Cellpose?

### DIFF
--- a/resources/scripts/cellpose_script.groovy
+++ b/resources/scripts/cellpose_script.groovy
@@ -12,7 +12,7 @@ IJ.runMacro("close('\\\\Others');")
 def cellCellpose = new Cellpose_SegmentImgPlusOwnModelAdvanced();
 cellCellpose.imp = imp;
 cellCellpose.diameter = 50;
-//cellCellpose.cellproba_threshold = 0;
+//cellCellpose.cellprob_threshold = 0;
 //cellCellpose.flow_threshold = 0.4;
 cellCellpose.model = "cyto2";
 cellCellpose.nuclei_channel = 2 ;

--- a/src/main/java/ch/epfl/biop/wrappers/cellpose/ij2commands/Cellpose_SegmentImgPlusAdvanced.java
+++ b/src/main/java/ch/epfl/biop/wrappers/cellpose/ij2commands/Cellpose_SegmentImgPlusAdvanced.java
@@ -27,8 +27,8 @@ public class Cellpose_SegmentImgPlusAdvanced implements Command {
     @Parameter(label = "Diameter (default 17 for nuclei, 30 for cyto,0 for automatic detection)")
     int diameter = 30;
 
-    @Parameter(label = "cellproba_threshold / mask_threshold (v0.6 / v0.7)")
-    double cellproba_threshold = 0.0;
+    @Parameter(label = "cellprob_threshold / mask_threshold (v0.6 / v0.7)")
+    double cellprob_threshold = 0.0;
 
     @Parameter(label = "flow_threshold (default 0.4)")
     double flow_threshold = 0.4;
@@ -93,7 +93,7 @@ public class Cellpose_SegmentImgPlusAdvanced implements Command {
         Cellpose_SegmentImgPlusOwnModelAdvanced cellpose = new Cellpose_SegmentImgPlusOwnModelAdvanced();
         cellpose.imp = imp;
         cellpose.diameter = diameter;
-        cellpose.cellproba_threshold = cellproba_threshold;
+        cellpose.cellprob_threshold = cellprob_threshold;
         cellpose.flow_threshold = flow_threshold;
         cellpose.anisotropy = anisotropy;
         cellpose.diam_threshold = diam_threshold;

--- a/src/main/java/ch/epfl/biop/wrappers/cellpose/ij2commands/Cellpose_SegmentImgPlusOwnModelAdvanced.java
+++ b/src/main/java/ch/epfl/biop/wrappers/cellpose/ij2commands/Cellpose_SegmentImgPlusOwnModelAdvanced.java
@@ -41,8 +41,8 @@ public class Cellpose_SegmentImgPlusOwnModelAdvanced implements Command {
     @Parameter(label = "Diameter (default 17 for nuclei, 30 for cyto,0 for automatic detection)")
     int diameter = 30;
 
-    @Parameter(label = "cellproba_threshold / mask_threshold (v0.6 / v0.7)")
-    double cellproba_threshold = 0.0;
+    @Parameter(label = "cellprob_threshold / mask_threshold (v0.6 / v0.7)")
+    double cellprob_threshold = 0.0;
 
     @Parameter(label = "flow_threshold (default 0.4)")
     double flow_threshold = 0.4;
@@ -173,7 +173,7 @@ public class Cellpose_SegmentImgPlusOwnModelAdvanced implements Command {
         settings.setModel(model);
 
         settings.setDiameter(diameter);
-        settings.setCellProbTh(cellproba_threshold);
+        settings.setCellProbTh(cellprob_threshold);
         settings.setFlowTh(flow_threshold);
         settings.setAnisotropy(anisotropy);
         settings.setDiamThreshold(diam_threshold);

--- a/src/main/java/ch/epfl/biop/wrappers/cellpose/ij2commands/Cellpose_SegmentNucleiImgPlusAdvanced.java
+++ b/src/main/java/ch/epfl/biop/wrappers/cellpose/ij2commands/Cellpose_SegmentNucleiImgPlusAdvanced.java
@@ -25,8 +25,8 @@ public class Cellpose_SegmentNucleiImgPlusAdvanced implements Command {
     @Parameter
     int diameter = 17;
 
-    @Parameter(label = "cellproba_threshold / mask_threshold (v0.6 / v0.7)")
-    double cellproba_threshold = 0.0;
+    @Parameter(label = "cellprob_threshold / mask_threshold (v0.6 / v0.7)")
+    double cellprob_threshold = 0.0;
 
     @Parameter
     double flow_threshold = 0.4;
@@ -45,7 +45,7 @@ public class Cellpose_SegmentNucleiImgPlusAdvanced implements Command {
         Cellpose_SegmentImgPlusAdvanced nucleiCellpose = new Cellpose_SegmentImgPlusAdvanced();
         nucleiCellpose.imp = imp;
         nucleiCellpose.diameter = diameter;
-        nucleiCellpose.cellproba_threshold = cellproba_threshold;
+        nucleiCellpose.cellprob_threshold = cellprob_threshold;
         nucleiCellpose.flow_threshold = flow_threshold;
 
         nucleiCellpose.model = "nuclei";

--- a/src/main/java/ch/epfl/biop/wrappers/cellpose/ij2commands/Cellpose_SegmentNucleiImgPlusBasic.java
+++ b/src/main/java/ch/epfl/biop/wrappers/cellpose/ij2commands/Cellpose_SegmentNucleiImgPlusBasic.java
@@ -25,7 +25,7 @@ public class Cellpose_SegmentNucleiImgPlusBasic implements Command {
         nucSeg.imp = imp;
         nucSeg.nuclei_channel = 1;
         nucSeg.diameter = 17;
-        nucSeg.cellproba_threshold = 0.0;
+        nucSeg.cellprob_threshold = 0.0;
         nucSeg.flow_threshold = 0.4;
         nucSeg.dimensionMode = "3D";
         nucSeg.run();

--- a/src/test/java/DemoCellpose.java
+++ b/src/test/java/DemoCellpose.java
@@ -69,7 +69,7 @@ public class DemoCellpose {
                 "imp",nuc3D_imp,
                 "nuclei_channel",1,
                 "diameter" , 30,
-                "cellproba_threshold", 0.0,
+                "cellprob_threshold", 0.0,
                 "flow_threshold" , 0.4,
                 "dimensionMode","3D").get().getOutput("cellpose_imp");
         nucLabel3D_imp.show();
@@ -85,7 +85,7 @@ public class DemoCellpose {
         ImagePlus cytoLabel_imp = (ImagePlus) ij.command().run(Cellpose_SegmentImgPlusAdvanced.class, true,
                 "imp",cyto_3D_imp,
                 "diameter" , 55,
-                "cellproba_threshold", 0.0,
+                "cellprob_threshold", 0.0,
                 "flow_threshold" , 0.4,
                 "model" , "cyto (no nuclei)",
                 "nuclei_channel",-1,
@@ -100,7 +100,7 @@ public class DemoCellpose {
         ImagePlus cytoLabel2chs_imp = (ImagePlus) ij.command().run(Cellpose_SegmentImgPlusAdvanced.class, true,
                 "imp",imp,
                 "diameter" , 55,
-                "cellproba_threshold", 0.0,
+                "cellprob_threshold", 0.0,
                 "flow_threshold" , 0.4,
                 "model" , "cyto",
                 "nuclei_channel",1,


### PR DESCRIPTION
Hi guys,

this is actually more of a question / suggestion than a real PR, so please feel free to decline or whatever!

We've been pretty puzzled today when looking for the _mask_ or _cellprobability_ threshold parameters (particularly using the `Cellpose_SegmentImgPlusAdvanced` class) and realized that the wrapper is using `cellproba_threshold` whereas Cellpose is using the term `cellprob_threshold`.

I'm aware this is a breaking change for now, hence I would like to put it up for discussion. Nevertheless having a different name is currently very confusing if you start searching for the given string e.g. in the Cellpose documentation or code repo.

What's your opinion on this?

All the best,
~Niko