### PR TITLE
Add a ramdom number to the temp folder to avoid conflicts when parall…

### DIFF
--- a/src/main/java/ch/epfl/biop/wrappers/cellpose/ij2commands/Cellpose.java
+++ b/src/main/java/ch/epfl/biop/wrappers/cellpose/ij2commands/Cellpose.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.List;
 
 @SuppressWarnings({"CanBeFinal", "unused"})
@@ -139,7 +140,8 @@ public class Cellpose implements Command {
         // We'll have the current time-point of the imp in a temp folder
         String tempDir = IJ.getDirectory("Temp");
         // create tempdir
-        File cellposeTempDir = new File(tempDir, "cellposeTemp");
+        int cellposeTempDirRandomNum = ThreadLocalRandom.current().nextInt(1, 10000);
+        File cellposeTempDir = new File(tempDir, "cellposeTemp_" + cellposeTempDirRandomNum);
         cellposeTempDir.mkdir();
 
         // when plugin crashes, image file can pile up in the folder, so we make sure to clear everything


### PR DESCRIPTION
This PR aims to :
 - Add a ramdom number to the temp folder to avoid conflicts when multiple instances run in parallel

It's motivated because we provide a shared computing infrastruture (HPC). When two users are using ImageJ/Cellpose at the same time, there are conflicts on the files within `/tmp/cellposeTemp/`.

I'm the infrastructure admin. I propose this commit for my users (ping @mariescopy). To be honest, I didn't try the fix and have no clue how to do this.
